### PR TITLE
fix: support type number in headers

### DIFF
--- a/apps/koa/package.json
+++ b/apps/koa/package.json
@@ -27,7 +27,7 @@
     "vitest": "^1.5.0"
   },
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^0.27.2",
     "cross-env": "^7.0.3",
     "koa": "^2.15.3",
     "koa-body": "^6.0.1",

--- a/apps/koa/src/index.js
+++ b/apps/koa/src/index.js
@@ -90,6 +90,12 @@ const run = () => {
     const res = await axios.get('http://www.baidu.com')
     ctx.body = res.data
   })
+  router.get('/headerWithNumber', async (ctx) => {
+    const res = await axios.get('http://www.baidu.com', {
+      headers: { 'test-timestamp': Date.now() }
+    })
+    ctx.body = res.data
+  })
 
   router.get('/fetch', async (ctx) => {
     const res = await fetch('https://jsonplaceholder.typicode.com/posts')

--- a/packages/network-debugger/src/fork/devtool.ts
+++ b/packages/network-debugger/src/fork/devtool.ts
@@ -159,6 +159,12 @@ export class DevtoolServer {
     const headerPipe = new RequestHeaderPipe(request.requestHeaders)
     const contentType = headerPipe.getHeader('content-type')
 
+    for (let key in request.requestHeaders){
+      if(typeof request.requestHeaders[key] === 'number'){
+         request.requestHeaders[key] = String(request.requestHeaders[key])
+      }
+    }
+    
     return this.send({
       method: 'Network.requestWillBeSent',
       params: {


### PR DESCRIPTION
node环境，发送带number类型的值的header的请求，未展示在devtools内
cdp对headers似乎只认string类型的键值对，但是拦截到的headers很有可能会遇到number类型，在stringify后cdp不认识