### PR TITLE
feat: integrate native node network scope debugging

### DIFF
--- a/packages/network-debugger/src/core/fork.test.ts
+++ b/packages/network-debugger/src/core/fork.test.ts
@@ -51,8 +51,8 @@ vi.mock('ws', () => {
 
   function MockWebSocket(this: EventEmitter) {
     EventEmitter.call(this)
-    this.send = mockWsSend
-    this.terminate = mockWsTerminate
+    (this as any).send = mockWsSend
+    (this as any).terminate = mockWsTerminate
     const originalRemoveAllListeners = this.removeAllListeners.bind(this)
     this.removeAllListeners = function () {
       mockWsRemoveAllListeners()

--- a/packages/network-debugger/src/core/fork.ts
+++ b/packages/network-debugger/src/core/fork.ts
@@ -36,6 +36,7 @@ export class MainProcess {
       const inspector = require('inspector')
       // Check if native inspector is active and supports Network
       if (inspector.url() && inspector.Network) {
+        warn(`[Network Debugger] Detected native Node inspector. Hijacking inspector.Network to forward CDP events to native DevTools.`)
         this.nativeNetwork = { ...inspector.Network }
         // Disable native network tracking to prevent duplicate logs
         const methods = [
@@ -56,7 +57,7 @@ export class MainProcess {
         this.options.autoOpenDevtool = false
       }
     } catch (e) {
-      // ignore
+      warn(`[Network Debugger] Error during native inspector setup: ${e}`)
     }
 
     this.ws = new Promise<WebSocket>(async (resolve, reject) => {
@@ -89,12 +90,16 @@ export class MainProcess {
               if (method && method.startsWith('Network.')) {
                 const methodName = method.split('.')[1]
                 if (typeof this.nativeNetwork[methodName] === 'function') {
-                  this.nativeNetwork[methodName](params)
+                  try {
+                    this.nativeNetwork[methodName](params)
+                  } catch (err) {
+                    warn(`[Network Debugger] Native network forwarding error for method ${method}: ${err}`)
+                  }
                 }
               }
             }
           } catch (e) {
-            // ignore
+            // ignore JSON parse errors
           }
         })
       }

--- a/packages/network-debugger/src/core/fork.ts
+++ b/packages/network-debugger/src/core/fork.ts
@@ -4,6 +4,7 @@ import WebSocket from 'ws'
 import { ChildProcess, fork } from 'child_process'
 import { __dirname } from '../common'
 import { resolve as resolvePath } from 'path'
+import { IS_DEV_MODE } from '../common'
 import { RegisterOptions } from '../common'
 import fs from 'fs'
 import { sleep, checkMainProcessAlive } from '../utils/process'
@@ -26,9 +27,38 @@ export class MainProcess {
   private ws: Promise<WebSocket>
   private options: RegisterOptions
   private cp?: ChildProcess
+  private nativeNetwork?: any
 
   constructor(props: RegisterOptions & { key: string }) {
-    this.options = props
+    this.options = { ...props }
+
+    try {
+      const inspector = require('inspector')
+      // Check if native inspector is active and supports Network
+      if (inspector.url() && inspector.Network) {
+        this.nativeNetwork = { ...inspector.Network }
+        // Disable native network tracking to prevent duplicate logs
+        const methods = [
+          'requestWillBeSent',
+          'responseReceived',
+          'loadingFinished',
+          'loadingFailed',
+          'dataSent',
+          'dataReceived'
+        ]
+        methods.forEach((method) => {
+          if (typeof (inspector.Network as any)[method] === 'function') {
+            ;(inspector.Network as any)[method] = () => {}
+          }
+        })
+
+        // Since the user is already connected to native devtools, don't open a new browser
+        this.options.autoOpenDevtool = false
+      }
+    } catch (e) {
+      // ignore
+    }
+
     this.ws = new Promise<WebSocket>(async (resolve, reject) => {
       const lockFilePath = resolvePath(__dirname, `./${props.key}`)
       if (fs.existsSync(lockFilePath)) {
@@ -50,8 +80,28 @@ export class MainProcess {
       }
       fs.writeFileSync(lockFilePath, `${process.pid}`)
       const socket = new WebSocket(`ws://localhost:${props.port}`)
+      const setupSocket = (s: WebSocket) => {
+        s.on('message', (msg) => {
+          try {
+            const data = JSON.parse(msg.toString())
+            if (data.type === 'cdp' && this.nativeNetwork) {
+              const { method, params } = data.data
+              if (method && method.startsWith('Network.')) {
+                const methodName = method.split('.')[1]
+                if (typeof this.nativeNetwork[methodName] === 'function') {
+                  this.nativeNetwork[methodName](params)
+                }
+              }
+            }
+          } catch (e) {
+            // ignore
+          }
+        })
+      }
+
       socket.on('open', () => {
         unlinkSafe(lockFilePath)
+        setupSocket(socket)
         resolve(socket)
       })
       socket.on('error', () => {
@@ -59,6 +109,7 @@ export class MainProcess {
           unlinkSafe(lockFilePath)
           const socket = new WebSocket(`ws://localhost:${props.port}`)
           socket.on('open', () => {
+            setupSocket(socket)
             resolve(socket)
           })
           socket.on('error', reject)

--- a/packages/network-debugger/src/fork/__tests__/cdp-protocol.test.ts
+++ b/packages/network-debugger/src/fork/__tests__/cdp-protocol.test.ts
@@ -17,7 +17,7 @@ describe('CDP Protocol Correctness Tests', () => {
       const messages: Array<{ method: string; timestamp?: number }> = []
 
       // 模拟 devtool.send 收集消息
-      const mockSend = vi.fn((msg: { method?: string; params?: { timestamp?: number } }) => {
+      const mockSend = vi.fn((msg: any) => {
         if (msg.method) {
           messages.push({
             method: msg.method,

--- a/packages/network-debugger/src/fork/devtool/index.ts
+++ b/packages/network-debugger/src/fork/devtool/index.ts
@@ -11,6 +11,7 @@ export interface DevtoolServerInitOptions {
   autoOpenDevtool?: boolean
   onConnect?: () => void
   onClose?: () => void
+  onSend?: (message: DevtoolMessage) => void
 }
 
 export interface IDevtoolServer {
@@ -26,10 +27,13 @@ export class DevtoolServer extends BaseDevtoolServer implements IDevtoolServer {
   private browser: ChildProcess | null = null
   private socket: Promise<[WebSocket]>
 
+  private onSend?: (message: DevtoolMessage) => void
+
   constructor(props: DevtoolServerInitOptions) {
     super()
-    const { port, autoOpenDevtool = true, onConnect, onClose } = props
+    const { port, autoOpenDevtool = true, onConnect, onClose, onSend } = props
     this.port = port
+    this.onSend = onSend
     this.server = new Server({ port })
     const { server } = this
 
@@ -135,6 +139,9 @@ export class DevtoolServer extends BaseDevtoolServer implements IDevtoolServer {
   }
 
   async send(message: DevtoolMessage) {
+    if (this.onSend) {
+      this.onSend(message)
+    }
     const [socket] = await this.socket
     return socket.send(JSON.stringify(message))
   }

--- a/packages/network-debugger/src/fork/module/common.test.ts
+++ b/packages/network-debugger/src/fork/module/common.test.ts
@@ -99,14 +99,14 @@ describe('fork/module/common.ts', () => {
       const plugins = [plugin]
 
       const result = plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins
       })
 
       expect(pluginFn).toHaveBeenCalledWith({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins
       })
       expect(result).toEqual({ result: 'test' })
@@ -123,8 +123,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       const result = plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -142,8 +142,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       const result = plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -165,8 +165,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -198,8 +198,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -222,8 +222,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -246,8 +246,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -279,8 +279,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -313,8 +313,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -346,14 +346,14 @@ describe('fork/module/common.ts', () => {
       const plugins = [plugin1, plugin2]
 
       plugin1({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins
       })
 
       plugin2({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins
       })
 
@@ -378,8 +378,8 @@ describe('fork/module/common.ts', () => {
       const mockCore = createMockCore()
 
       plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [plugin]
       })
 
@@ -403,8 +403,8 @@ describe('fork/module/common.ts', () => {
       const plugins = [plugin]
 
       plugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins
       })
 

--- a/packages/network-debugger/src/fork/module/health/index.test.ts
+++ b/packages/network-debugger/src/fork/module/health/index.test.ts
@@ -101,8 +101,8 @@ describe('fork/module/health/index.ts', () => {
       const mockCore = createMockCore()
 
       healthPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [healthPlugin]
       })
 
@@ -116,8 +116,8 @@ describe('fork/module/health/index.ts', () => {
       const mockCore = createMockCore()
 
       healthPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [healthPlugin]
       })
 
@@ -134,8 +134,8 @@ describe('fork/module/health/index.ts', () => {
       const mockCore = createMockCore()
 
       healthPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [healthPlugin]
       })
 
@@ -166,8 +166,8 @@ describe('fork/module/health/index.ts', () => {
       const mockCore = createMockCore()
 
       healthPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [healthPlugin]
       })
 
@@ -196,8 +196,8 @@ describe('fork/module/health/index.ts', () => {
       const mockCore = createMockCore()
 
       healthPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [healthPlugin]
       })
 

--- a/packages/network-debugger/src/fork/module/network/index.test.ts
+++ b/packages/network-debugger/src/fork/module/network/index.test.ts
@@ -134,8 +134,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -154,8 +154,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       const result = networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -173,8 +173,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       const result = networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -198,8 +198,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       const result = networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -235,8 +235,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       const pluginResult = networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -286,8 +286,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -325,8 +325,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -356,8 +356,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -386,8 +386,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       const pluginResult = networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -436,8 +436,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -479,8 +479,8 @@ describe('fork/module/network/index.ts', () => {
       registeredHandlers.clear()
 
       networkPlugin({
-        devtool: mockDevtool1,
-        core: mockCore1,
+        devtool: mockDevtool1 as any,
+        core: mockCore1 as any,
         plugins: []
       })
 
@@ -510,8 +510,8 @@ describe('fork/module/network/index.ts', () => {
       registeredHandlers.clear()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: []
       })
 
@@ -541,8 +541,8 @@ describe('fork/module/network/index.ts', () => {
       registeredHandlers.clear()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: []
       })
 
@@ -572,8 +572,8 @@ describe('fork/module/network/index.ts', () => {
       registeredHandlers.clear()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: []
       })
 
@@ -603,8 +603,8 @@ describe('fork/module/network/index.ts', () => {
       registeredHandlers.clear()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: []
       })
 
@@ -635,8 +635,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       const result = networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -676,8 +676,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -702,8 +702,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -730,8 +730,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -775,8 +775,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -808,8 +808,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -854,8 +854,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -900,8 +900,8 @@ describe('fork/module/network/index.ts', () => {
       const mockCore = createMockCore()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: [networkPlugin]
       })
 
@@ -948,8 +948,8 @@ describe('fork/module/network/index.ts', () => {
       registeredHandlers.clear()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: []
       })
 
@@ -981,8 +981,8 @@ describe('fork/module/network/index.ts', () => {
       registeredHandlers.clear()
 
       networkPlugin({
-        devtool: mockDevtool,
-        core: mockCore,
+        devtool: mockDevtool as any,
+        core: mockCore as any,
         plugins: []
       })
 

--- a/packages/network-debugger/src/fork/request-center.ts
+++ b/packages/network-debugger/src/fork/request-center.ts
@@ -1,6 +1,6 @@
 import { DevtoolServer } from './devtool'
 import { PORT, READY_MESSAGE, RequestDetail } from '../common'
-import { Server } from 'ws'
+import { Server, WebSocket } from 'ws'
 import { log } from '../utils'
 import { PluginInstance } from './module/common'
 
@@ -23,6 +23,7 @@ export interface DevtoolMessageListener<T = any> {
 export class RequestCenter {
   private devtool: DevtoolServer
   private server: Server
+  private clients: Set<WebSocket> = new Set()
   private listeners: Record<string, Set<DevtoolMessageListener> | undefined> = {}
   private options: RequestCenterInitOptions
   constructor(options: RequestCenterInitOptions) {
@@ -31,6 +32,14 @@ export class RequestCenter {
     this.devtool = new DevtoolServer({
       port: serverPort,
       autoOpenDevtool: autoOpenDevtool,
+      onSend: (message) => {
+        const payload = JSON.stringify({ type: 'cdp', data: message })
+        this.clients.forEach(client => {
+          if (client.readyState === 1 /* WebSocket.OPEN */) {
+            client.send(payload)
+          }
+        })
+      },
       onConnect: () => {
         const listeners = this.listeners['onConnect']
         listeners?.forEach((listener) =>
@@ -105,6 +114,10 @@ export class RequestCenter {
   private initServer() {
     const server = new Server({ port: this.options.port || PORT })
     server.on('connection', (ws) => {
+      this.clients.add(ws)
+      ws.on('close', () => {
+        this.clients.delete(ws)
+      })
       ws.on('message', (data) => {
         const message = JSON.parse(data.toString())
         const _message = message as { type: string; data: any }

--- a/packages/network-debugger/src/fork/request-center.ts
+++ b/packages/network-debugger/src/fork/request-center.ts
@@ -33,12 +33,14 @@ export class RequestCenter {
       port: serverPort,
       autoOpenDevtool: autoOpenDevtool,
       onSend: (message) => {
-        const payload = JSON.stringify({ type: 'cdp', data: message })
-        this.clients.forEach(client => {
-          if (client.readyState === 1 /* WebSocket.OPEN */) {
-            client.send(payload)
-          }
-        })
+        if (this.clients.size > 0) {
+          const payload = JSON.stringify({ type: 'cdp', data: message })
+          this.clients.forEach(client => {
+            if (client.readyState === 1 /* WebSocket.OPEN */) {
+              client.send(payload)
+            }
+          })
+        }
       },
       onConnect: () => {
         const listeners = this.listeners['onConnect']
@@ -114,8 +116,10 @@ export class RequestCenter {
   private initServer() {
     const server = new Server({ port: this.options.port || PORT })
     server.on('connection', (ws) => {
+      // log(`[Network Debugger] DevTools client connected to RequestCenter.`)
       this.clients.add(ws)
       ws.on('close', () => {
+        // log(`[Network Debugger] DevTools client disconnected from RequestCenter.`)
         this.clients.delete(ws)
       })
       ws.on('message', (data) => {

--- a/packages/network-debugger/test.js
+++ b/packages/network-debugger/test.js
@@ -1,0 +1,12 @@
+const { register } = require('./dist/index.js');
+const http = require('http');
+
+register();
+console.log('Registered network-debugger');
+
+setTimeout(() => {
+    http.get('http://example.com', (res) => {
+        console.log('Response status:', res.statusCode);
+        res.on('data', () => {});
+    });
+}, 2000);


### PR DESCRIPTION
Integrates the network debugger with the native Node.js inspector network domain, suppressing native logs while using its WebSocket to output custom network information without opening a separate browser. This addresses new node experimental network scope features.

---
*PR created automatically by Jules for task [3260377472769035350](https://jules.google.com/task/3260377472769035350) started by @GrinZero*