### PR TITLE
fix: preserve raw request data to fix [object Object] display issue

### DIFF
--- a/apps/koa-esm/src/index.js
+++ b/apps/koa-esm/src/index.js
@@ -77,6 +77,45 @@ router.get('/fetch', async (ctx) => {
   ctx.body = data
 })
 
+// Test case 1: text/plain + JSON body
+router.get('/post-text-plain', async (ctx) => {
+  const res = await axios.post(
+    'https://jsonplaceholder.typicode.com/posts',
+    JSON.stringify({ title: 'foo', body: 'bar', userId: 1 }),
+    { headers: { 'Content-Type': 'text/plain' } }
+  )
+  ctx.body = res.data
+})
+
+// Test case 2: application/x-www-form-urlencoded
+router.get('/post-form', async (ctx) => {
+  const res = await axios.post(
+    'https://jsonplaceholder.typicode.com/posts',
+    'title=foo&body=bar&userId=1',
+    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+  )
+  ctx.body = res.data
+})
+
+// Test case 3: pure text body
+router.get('/post-pure-text', async (ctx) => {
+  const res = await axios.post(
+    'https://jsonplaceholder.typicode.com/posts',
+    'This is a plain text message',
+    { headers: { 'Content-Type': 'text/plain' } }
+  )
+  ctx.body = res.data
+})
+
+// Test case 4: Buffer body
+router.get('/post-buffer', async (ctx) => {
+  const buffer = Buffer.from(JSON.stringify({ title: 'buffer', body: 'test', userId: 1 }))
+  const res = await axios.post('https://jsonplaceholder.typicode.com/posts', buffer, {
+    headers: { 'Content-Type': 'application/json' }
+  })
+  ctx.body = res.data
+})
+
 app.use(router.routes())
 app.listen(3001)
 

--- a/packages/network-debugger/src/core/request.ts
+++ b/packages/network-debugger/src/core/request.ts
@@ -22,12 +22,8 @@ function proxyClientRequestFactory(
 ) {
   const actualFn = actualRequest.write
   actualRequest.write = (data: any) => {
-    try {
-      requestDetail.requestData = JSON.parse(data.toString())
-    } catch (err) {
-      requestDetail.requestData = data
-    }
-
+    // 保持原始数据格式，由 DevTools 自行解析展示
+    requestDetail.requestData = data
     return actualFn.bind(actualRequest)(data)
   }
 

--- a/packages/network-debugger/src/core/request.ts
+++ b/packages/network-debugger/src/core/request.ts
@@ -22,8 +22,25 @@ function proxyClientRequestFactory(
 ) {
   const actualFn = actualRequest.write
   actualRequest.write = (data: any) => {
-    // 保持原始数据格式，由 DevTools 自行解析展示
-    requestDetail.requestData = data
+    // Convert to string at source to avoid IPC serialization issues
+    // Accumulate multiple writes (e.g., multipart/form-data)
+    let chunk: string
+    if (Buffer.isBuffer(data)) {
+      chunk = data.toString('utf-8')
+    } else if (typeof data === 'string') {
+      chunk = data
+    } else if (data != null) {
+      chunk = JSON.stringify(data)
+    } else {
+      chunk = ''
+    }
+
+    if (requestDetail.requestData) {
+      requestDetail.requestData += chunk
+    } else {
+      requestDetail.requestData = chunk
+    }
+
     return actualFn.bind(actualRequest)(data)
   }
 

--- a/packages/network-debugger/src/fork/module/network/index.ts
+++ b/packages/network-debugger/src/fork/module/network/index.ts
@@ -180,11 +180,7 @@ export const networkPlugin = createPlugin('network', ({ devtool, core }) => {
           initialPriority: 'High',
           mixedContentType: 'none',
           ...(request.requestData
-            ? {
-                postData: contentType?.includes('application/json')
-                  ? JSON.stringify(request.requestData)
-                  : request.requestData
-              }
+            ? { postData: request.requestData.toString() }
             : {})
         },
         timestamp: devtool.timestamp,


### PR DESCRIPTION
## Problem
When sending HTTP requests with `text/plain` Content-Type but JSON body (e.g., some logging SDKs), the DevTools Network panel shows `[object Object]` instead of the actual request payload.

## Root Cause
In `request.ts`, the code unnecessarily parses the request data with `JSON.parse()`, converting the string to an object. Later in `index.ts`, when building the CDP `postData` field, it only re-serializes for `application/json` Content-Type, leaving `text/plain` requests with an object that becomes `[object Object]`.

## Solution
- Remove unnecessary `JSON.parse()` in `request.ts`, keep raw data format
- Simplify `postData` handling in `index.ts` to always use `.toString()`
- Let Chrome DevTools handle JSON parsing and display (which it does correctly)

## Changes
- `packages/network-debugger/src/core/request.ts`: Remove JSON.parse, preserve original data
- `packages/network-debugger/src/fork/module/network/index.ts`: Simplify to `request.requestData.toString()`