### PR TITLE
chore: replace all localhost with 127.0.0.1

### DIFF
--- a/apps/web/docs/options.md
+++ b/apps/web/docs/options.md
@@ -33,7 +33,7 @@ register(options)
 ### serverPort
 
 - **Description**: CDP server port for Devtool
-- **Link**: [devtools://devtools/bundled/inspector.html?ws=localhost:${serverPort}](devtools://devtools/bundled/inspector.html?ws=localhost:${serverPort})
+- **Link**: [devtools://devtools/bundled/inspector.html?ws=127.0.0.1:${serverPort}](devtools://devtools/bundled/inspector.html?ws=127.0.0.1:${serverPort})
 - **Default value**: `5271`
 
 ### autoOpenDevtool

--- a/apps/web/docs/zh/options.md
+++ b/apps/web/docs/zh/options.md
@@ -33,7 +33,7 @@ register(options)
 ### serverPort
 
 - **描述**: CDP 服务器端口，用于 Devtool
-- **链接**: [devtools://devtools/bundled/inspector.html?ws=localhost:${serverPort}](devtools://devtools/bundled/inspector.html?ws=localhost:${serverPort})
+- **链接**: [devtools://devtools/bundled/inspector.html?ws=127.0.0.1:${serverPort}](devtools://devtools/bundled/inspector.html?ws=127.0.0.1:${serverPort})
 - **默认值**: `5271`
 
 ### autoOpenDevtool

--- a/packages/network-debugger/src/__tests__/helpers/test-utils.ts
+++ b/packages/network-debugger/src/__tests__/helpers/test-utils.ts
@@ -91,7 +91,7 @@ export function createCDPMessage(overrides?: Partial<MockCDPMessage>): MockCDPMe
 export function createMockRequestOptions(overrides?: Record<string, unknown>) {
   return {
     method: 'GET',
-    hostname: 'localhost',
+    hostname: '127.0.0.1',
     port: 80,
     path: '/',
     headers: {},

--- a/packages/network-debugger/src/common.test.ts
+++ b/packages/network-debugger/src/common.test.ts
@@ -255,23 +255,23 @@ describe('RequestDetail', () => {
   })
 
   describe('isHiden', () => {
-    test('should return true for ws://localhost/ websocket connections', () => {
+    test('should return true for ws://127.0.0.1/ websocket connections', () => {
       const requestDetail = new RequestDetail()
       requestDetail.requestHeaders = { Upgrade: 'websocket' }
-      requestDetail.url = 'ws://localhost/'
+      requestDetail.url = 'ws://127.0.0.1/'
 
       expect(requestDetail.isHiden()).toBe(true)
     })
 
-    test('should return true for http://localhost/ websocket connections', () => {
+    test('should return true for http://127.0.0.1/ websocket connections', () => {
       const requestDetail = new RequestDetail()
       requestDetail.requestHeaders = { Upgrade: 'websocket' }
-      requestDetail.url = 'http://localhost/'
+      requestDetail.url = 'http://127.0.0.1/'
 
       expect(requestDetail.isHiden()).toBe(true)
     })
 
-    test('should return false for non-localhost websocket connections', () => {
+    test('should return false for non-127.0.0.1 websocket connections', () => {
       const requestDetail = new RequestDetail()
       requestDetail.requestHeaders = { Upgrade: 'websocket' }
       requestDetail.url = 'ws://example.com/'
@@ -279,26 +279,26 @@ describe('RequestDetail', () => {
       expect(requestDetail.isHiden()).toBe(false)
     })
 
-    test('should return false for non-websocket localhost connections', () => {
+    test('should return false for non-websocket 127.0.0.1 connections', () => {
       const requestDetail = new RequestDetail()
       requestDetail.requestHeaders = { 'Content-Type': 'application/json' }
-      requestDetail.url = 'http://localhost/'
+      requestDetail.url = 'http://127.0.0.1/'
 
       expect(requestDetail.isHiden()).toBe(false)
     })
 
-    test('should return false for websocket with different localhost path', () => {
+    test('should return false for websocket with different 127.0.0.1 path', () => {
       const requestDetail = new RequestDetail()
       requestDetail.requestHeaders = { Upgrade: 'websocket' }
-      requestDetail.url = 'ws://localhost/api'
+      requestDetail.url = 'ws://127.0.0.1/api'
 
       expect(requestDetail.isHiden()).toBe(false)
     })
 
-    test('should return false for websocket with localhost and port', () => {
+    test('should return false for websocket with 127.0.0.1 and port', () => {
       const requestDetail = new RequestDetail()
       requestDetail.requestHeaders = { Upgrade: 'websocket' }
-      requestDetail.url = 'ws://localhost:8080/'
+      requestDetail.url = 'ws://127.0.0.1:8080/'
 
       expect(requestDetail.isHiden()).toBe(false)
     })
@@ -311,10 +311,10 @@ describe('RequestDetail', () => {
       expect(requestDetail.isHiden()).toBe(false)
     })
 
-    test('should return false for wss://localhost/ (secure websocket)', () => {
+    test('should return false for wss://127.0.0.1/ (secure websocket)', () => {
       const requestDetail = new RequestDetail()
       requestDetail.requestHeaders = { Upgrade: 'websocket' }
-      requestDetail.url = 'wss://localhost/'
+      requestDetail.url = 'wss://127.0.0.1/'
 
       expect(requestDetail.isHiden()).toBe(false)
     })

--- a/packages/network-debugger/src/common.ts
+++ b/packages/network-debugger/src/common.ts
@@ -47,7 +47,7 @@ export class RequestDetail {
   }
 
   isHiden() {
-    return this.isWebSocket() && ['http://localhost/', 'ws://localhost/'].includes(this.url!)
+    return this.isWebSocket() && ['http://127.0.0.1/', 'ws://127.0.0.1/'].includes(this.url!)
   }
 
   isWebSocket() {
@@ -99,7 +99,7 @@ export interface RegisterOptions {
   port?: number
   /**
    * @description CDP Server Port, used for Devtool
-   * @link devtools://devtools/bundled/inspector.html?ws=localhost:${serverPort}
+   * @link devtools://devtools/bundled/inspector.html?ws=127.0.0.1:${serverPort}
    * @default 5271
    */
   serverPort?: number

--- a/packages/network-debugger/src/core/fork.ts
+++ b/packages/network-debugger/src/core/fork.ts
@@ -49,7 +49,7 @@ export class MainProcess {
         unlinkSafe(lockFilePath)
       }
       fs.writeFileSync(lockFilePath, `${process.pid}`)
-      const socket = new WebSocket(`ws://localhost:${props.port}`)
+      const socket = new WebSocket(`ws://127.0.0.1:${props.port}`)
       socket.on('open', () => {
         unlinkSafe(lockFilePath)
         resolve(socket)
@@ -57,7 +57,7 @@ export class MainProcess {
       socket.on('error', () => {
         this.openProcess(() => {
           unlinkSafe(lockFilePath)
-          const socket = new WebSocket(`ws://localhost:${props.port}`)
+          const socket = new WebSocket(`ws://127.0.0.1:${props.port}`)
           socket.on('open', () => {
             resolve(socket)
           })

--- a/packages/network-debugger/src/core/request.test.ts
+++ b/packages/network-debugger/src/core/request.test.ts
@@ -749,9 +749,9 @@ describe('core/request.ts', () => {
           mockMainProcess as never
         )
 
-        // 使用 localhost 的隐藏 URL
+        // 使用 127.0.0.1 的隐藏 URL
         const options: RequestOptions = {
-          hostname: 'localhost',
+          hostname: '127.0.0.1',
           path: '/',
           method: 'GET',
           headers: {

--- a/packages/network-debugger/src/fork/devtool/index.ts
+++ b/packages/network-debugger/src/fork/devtool/index.ts
@@ -62,7 +62,7 @@ export class DevtoolServer extends BaseDevtoolServer implements IDevtoolServer {
   }
 
   public async open() {
-    const url = `devtools://devtools/bundled/inspector.html?ws=localhost:${this.port}`
+    const url = `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:${this.port}`
     try {
       if (IS_DEV_MODE) {
         log(`In dev mode, open chrome devtool manually: ${url}`)
@@ -90,7 +90,7 @@ export class DevtoolServer extends BaseDevtoolServer implements IDevtoolServer {
               }
               try {
                 count++
-                resolve((await fetch(`http://localhost:${REMOTE_DEBUGGER_PORT}/json`)).json())
+                resolve((await fetch(`http://127.0.0.1:${REMOTE_DEBUGGER_PORT}/json`)).json())
                 clearInterval(stop)
               } catch {
                 // ignore


### PR DESCRIPTION
This change replaces all occurrences of "localhost" with "127.0.0.1" in the codebase.
This prevents IPv6 resolution issues (ECONNREFUSED) that can occur in Node.js >= v17.

Modified files:
- apps/web/docs/options.md
- apps/web/docs/zh/options.md
- packages/network-debugger/src/__tests__/helpers/test-utils.ts
- packages/network-debugger/src/common.test.ts
- packages/network-debugger/src/common.ts
- packages/network-debugger/src/core/fork.ts
- packages/network-debugger/src/core/request.test.ts
- packages/network-debugger/src/fork/devtool/index.ts

---
*PR created automatically by Jules for task [2802622098436140001](https://jules.google.com/task/2802622098436140001) started by @GrinZero*