### PR TITLE
fix: send responseReceived with EventSource type for SSE requests

### DIFF
--- a/packages/network-debugger/src/core/fetch.ts
+++ b/packages/network-debugger/src/core/fetch.ts
@@ -39,6 +39,8 @@ export function fetchProxyFactory(fetchFn: typeof fetch, mainProcess: MainProces
     }
     requestDetail.requestData = options?.body
 
+    requestDetail.loadCallFrames()
+
     const result = fetchFn(request as string | Request, options)
       .then(fetchResponseHandlerFactory(requestDetail, mainProcess))
       .catch(fetchErrorHandlerFactory(requestDetail, mainProcess))
@@ -80,8 +82,11 @@ async function handleEventStreamResponse(
   let buffer = ''
   const allChunks: Uint8Array[] = []
 
-  // Send initial response info
-  mainProcess.sendRequest('updateRequest', requestDetail)
+  // Send responseReceived first (type: EventSource) so DevTools knows this is an SSE request
+  mainProcess.send({
+    type: 'eventSourceResponseReceived',
+    data: requestDetail
+  })
 
   try {
     while (true) {

--- a/packages/network-debugger/src/fork/module/network/index.ts
+++ b/packages/network-debugger/src/fork/module/network/index.ts
@@ -197,6 +197,36 @@ export const networkPlugin = createPlugin('network', ({ devtool, core }) => {
     endRequest(request)
   })
 
+  // Handle SSE response received - send responseReceived with type: EventSource before streaming messages
+  useHandler<RequestDetail>('eventSourceResponseReceived', ({ data }) => {
+    const request = new RequestDetail(data)
+    requests[request.id] = request
+    devtool.updateTimestamp()
+    const headers = new RequestHeaderPipe(request.responseHeaders)
+    const contentType = headers.getHeader('content-type') || 'text/event-stream'
+
+    devtool.send({
+      method: 'Network.responseReceived',
+      params: {
+        requestId: request.id,
+        frameId,
+        loaderId,
+        timestamp: devtool.timestamp,
+        type: 'EventSource',
+        response: {
+          url: request.url,
+          status: request.responseStatusCode,
+          statusText: request.responseStatusCode === 200 ? 'OK' : '',
+          headers: request.responseHeaders,
+          connectionReused: false,
+          encodedDataLength: 0,
+          charset: 'utf-8',
+          mimeType: toMimeType(contentType)
+        }
+      }
+    })
+  })
+
   useHandler<{
     id: string
     rawData: Array<number>


### PR DESCRIPTION
# PR: Fix SSE (Server-Sent Events) DevTools Display

## Summary

This PR fixes the SSE request display in Chrome DevTools Network panel by sending `Network.responseReceived` with `type: EventSource` before streaming SSE messages.

## Changes

### `packages/network-debugger/src/core/fetch.ts`
- Add `loadCallFrames()` call to capture initiator stack trace for fetch requests
- Send `eventSourceResponseReceived` message to properly notify DevTools about SSE responses

### `packages/network-debugger/src/fork/module/network/index.ts`
- Add new handler `eventSourceResponseReceived` to send `Network.responseReceived` with `type: EventSource`
- This ensures DevTools correctly identifies and displays SSE requests

## Why

Previously, SSE requests were not properly displayed in DevTools because the `responseReceived` event was not sent with the correct `type: EventSource`. This fix ensures:
1. SSE requests show up correctly in the Network panel
2. The request type is properly identified as `EventSource`
3. Initiator stack trace is captured for better debugging

## Testing

Tested with `koa-esm` app's `/sse-fetch` endpoint - SSE events are now properly captured and displayed in DevTools.
